### PR TITLE
[#55] update : post list

### DIFF
--- a/src/components/pages/postList.tsx
+++ b/src/components/pages/postList.tsx
@@ -55,20 +55,20 @@ const PostList = ({ searchParams, postListDataResponse }: PostListProps) => {
           activeTab={activeTab}
           setActiveTab={handleTabChange}
         />
+        <SubCategoryGroup>
+          <CategoryCategory
+            label="튜터"
+            filterData={getFetchTutors || []}
+            defaultValue={tutor}
+            setValue={(value) => {
+              setTutor(value);
+              updateQueryParams('tutorId', value, setCurrentPage);
+            }}
+          />
+        </SubCategoryGroup>
         {!!postListData &&
           (postListData.data.totalElements > 0 ? (
             <>
-              <SubCategoryGroup>
-                <CategoryCategory
-                  label="튜터"
-                  filterData={getFetchTutors || []}
-                  defaultValue={tutor}
-                  setValue={(value) => {
-                    setTutor(value);
-                    updateQueryParams('tutorId', value, setCurrentPage);
-                  }}
-                />
-              </SubCategoryGroup>
               <PostListContainer postListData={postListData} />
               <PageNation
                 currentPage={currentPage}


### PR DESCRIPTION
## 개요
게시물 목록에 게시물이 없을 때, 튜터,최신순,가나다순 등의 필터가 사라지는 부분 수정

## 작업사항

- [x] 게시물 목록에 게시물이 없을 때, 튜터,최신순,가나다순 등의 필터가 사라지는 부분 수정

## 관련 이슈

- [x] close #55 
