### PR TITLE
update : tag 검색 변경 

### DIFF
--- a/src/app/(rootLayout)/(home)/page.tsx
+++ b/src/app/(rootLayout)/(home)/page.tsx
@@ -64,7 +64,6 @@ const page = async ({ searchParams }: PostProps) => {
     if (axios.isAxiosError(error)) {
       const data = error?.response?.data;
       const status = error?.response?.status;
-      console.log(error.response);
 
       return <CustomError errorData={{ status, data }}></CustomError>;
     }

--- a/src/components/molecules/post/tagNamegroup.tsx
+++ b/src/components/molecules/post/tagNamegroup.tsx
@@ -47,10 +47,10 @@ const TagNameGroup = ({ tagList }: TagNameGroupProps) => {
     >
       {visibleTags.map((tag) => (
         <TagName
-          href={`/tag?tagId=${tag.tagId}&tagName=${tag.tagName}&page=${DEFAULT_PAGE}&size=${DEFAULT_PAGE_SIZE}`}
+          href={`/?title=%23${tag.tagName}&page=${DEFAULT_PAGE}&size=${DEFAULT_PAGE_SIZE}`}
           key={tag.tagId}
         >
-          {tag.tagName}
+          #{tag.tagName}
         </TagName>
       ))}
     </section>

--- a/src/components/molecules/postDetail/postDetailTag.tsx
+++ b/src/components/molecules/postDetail/postDetailTag.tsx
@@ -1,13 +1,20 @@
 import TagCard from '@/components/molecules/tagCard';
 import { TagType } from '@/types/tag.types';
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from '@/constatns/posts.constant';
+import TagName from '@/components/atoms/post/tagNameProps';
 
 const PostDetailTag = ({ tags }: { tags: TagType[] }) => {
   return (
     <div className="flex flex-wrap gap-[7.73px]">
       {tags.map((tag, index) => (
-        <TagCard key={index} className="pr-3">
-          {tag.tagName}
-        </TagCard>
+        <TagName
+          href={`/?title=%23${tag.tagName}&page=${DEFAULT_PAGE}&size=${DEFAULT_PAGE_SIZE}`}
+          key={tag.tagId}
+        >
+          <TagCard key={index} className="pr-3">
+            #{tag.tagName}
+          </TagCard>
+        </TagName>
       ))}
     </div>
   );

--- a/src/hooks/usePostList.ts
+++ b/src/hooks/usePostList.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAppSelector } from '@/redux/storeConfig';
 import useSearchTutor from '@/hooks/useSearchTutor';
 import { SearchParamsType } from '@/types/posts.types';
@@ -69,6 +69,10 @@ export const usePostList = (initialSearchParams: SearchParamsType) => {
       updateQueryParams('title', keyword, setCurrentPage);
     }
   };
+
+  useEffect(() => {
+    setKeyword(initialSearchParams.title || '');
+  }, [initialSearchParams?.title]);
 
   return {
     currentPage,


### PR DESCRIPTION
## 개요

기존 태그 검색 페이지를 제거하고
기존 검색 로직에서 #검색으로 태그를 검색할 수 있게 변경
게시글 리스트, 게시글 디테일에서 태그 클릭시  태그 검색 페이지로 넘어가게 변경

## 작업사항

- [ ] tag 검색 변경

## 관련 이슈

- [ ] close #61