### PR TITLE
[#102] fix:수준별 카테고리 빈 페이지일때 문구 수정 등

### DIFF
--- a/src/components/molecules/categoryGroup/categoryGroup.tsx
+++ b/src/components/molecules/categoryGroup/categoryGroup.tsx
@@ -17,7 +17,6 @@ const CategoryGroup = ({
 }: CategoryGroupProps) => {
   const { categoryData } = usePostTypeNames();
 
-  console.log({ categoryData });
   const activeCategory = categoryData.find(
     (category) => category.id === activeTab,
   );

--- a/src/components/organisms/searchInput.tsx
+++ b/src/components/organisms/searchInput.tsx
@@ -36,6 +36,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
   const {
     isOpen: isOpenSearchDropdown,
     dropdownRef,
+    setIsOpen,
     handleClick: handleClickSearchDropdown,
   } = useDropDownOpen();
 
@@ -78,7 +79,10 @@ const SearchInput: React.FC<SearchInputProps> = ({
         onChange={handleKeywordChange}
         onKeyDown={(e) => {
           handleSearchKeyDown(e);
-          if (e.key === 'Enter') onSearch();
+          if (e.key === 'Enter') {
+            onSearch();
+            setIsOpen(false);
+          }
         }}
       />
 

--- a/src/components/pages/postList.tsx
+++ b/src/components/pages/postList.tsx
@@ -9,9 +9,9 @@ import CategoryCategory from '@/components/molecules/categorySelector';
 import PostListContainer from '@/components/organisms/postList/postListContainer';
 import PageNation from '@/components/atoms/pageNation';
 import EmptyPage from '@/components/pages/emptyPage';
-import { postTabArr } from '@/constatns/post.constant';
 import HelperButton from '@/components/atoms/helperButton';
 import { useEffect, useState } from 'react';
+import usePostTypeNames from '@/hooks/usePostTypeNames';
 
 interface PostListProps {
   searchParams: SearchParamsType;
@@ -36,6 +36,8 @@ const PostList = ({ searchParams, postListDataResponse }: PostListProps) => {
     handleSearchClick,
     setCurrentPage,
   } = usePostList(searchParams);
+
+  const { categoryData } = usePostTypeNames();
 
   useEffect(() => {
     setPostListData(postListDataResponse);
@@ -80,7 +82,8 @@ const PostList = ({ searchParams, postListDataResponse }: PostListProps) => {
           ) : (
             <EmptyPage>
               {searchParams?.title ||
-                postTabArr.find((category) => category.id === activeTab)?.title}
+                categoryData.find((category) => category.id === activeTab)
+                  ?.title}
             </EmptyPage>
           ))}
       </section>


### PR DESCRIPTION
## 개요

- 수준별 카테고리 빈 페이지일때 문구 수정
- 검색 후 enter 했을때 dropdown 닫기

## 작업사항

- [x] 수준별 카테고리 빈 페이지일때 문구 수정
- [x] 검색 후 enter 했을때 dropdown 닫기

## 관련 이슈

- [x] close #102 
